### PR TITLE
Fixes for R Markdown files

### DIFF
--- a/Figure1.qmd
+++ b/Figure1.qmd
@@ -22,7 +22,7 @@ library(patchwork)
 ## Loading Preliminary Tuning Data
 
 ```{r}
-tuned.results <- list.files("~/Documents/GitHub/Ibex.manuscript/data/tuningRuns/Preliminary", 
+tuned.results <- list.files("./data/tuningRuns/Preliminary",
                                 full.names = TRUE)
 file.names <- str_split(tuned.results, "/", simplify = TRUE)[,ncol(str_split(tuned.results, "/", simplify = TRUE))]
 file.names <- str_remove_all(file.names, ".rds")
@@ -94,7 +94,7 @@ plot2 <- ggplot(scaled_results[tuned.results$variable == "latent_dim",],
           scale_color_viridis(discrete = TRUE) +
           scale_fill_viridis(discrete = TRUE) +
           facet_grid(.~optimizer) + 
-          heme_clean(base_size = 14) +
+           theme_clean(base_size = 14) +
           guides(linetype = "none") + 
           theme(legend.position = "right", 
                 plot.background = element_rect(color = NA))
@@ -104,7 +104,7 @@ ggsave("./outputs/Figure1/Figure1C.pdf", height = 5.5, width = 10)
 
 #############
 #Layer 2
-#############la",]
+#############
 plot3 <- ggplot(scaled_results[tuned.results$variable == "hidden_dim2",], 
                aes(x = as.numeric(value), y = scaled_score, color = group)) + 
                   geom_smooth(aes(linetype = optimizer, fill = group), 
@@ -145,7 +145,7 @@ ggsave("./outputs/Supplemental/SuppFigure1.pdf", height = 5.5, width = 10)
 Comparing results for Expanded Sequences (including amino acids from CDR1/2/3). These runs had set optimizer of Adam and activation ReLU.
 
 ```{r}
-expanded.results <- list.files("~/Documents/GitHub/Ibex.manuscript/data/tuningRuns/ExpandedSequence", 
+expanded.results <- list.files("./data/tuningRuns/ExpandedSequence",
                                full.names = TRUE)
 file.names <- str_split(expanded.results, "/", simplify = TRUE)[,ncol(str_split(expanded.results, "/", simplify = TRUE))]
 file.names <- str_remove_all(file.names, ".rds")
@@ -257,7 +257,7 @@ ggsave("./outputs/Figure1/Figure1E.pdf", height = 4.5, width = 6, dpi = 300)
 Looking at loss as a function of epoch, batch size and learning rate with fixed hidden and latent dimensions.
 
 ```{r}
-refined.results <- list.files("~/Documents/GitHub/Ibex.manuscript/data/tuningRuns/Refined", 
+refined.results <- list.files("./data/tuningRuns/Refined",
                                 full.names = TRUE)
 file.names <- str_split(refined.results, "/", simplify = TRUE)[,ncol(str_split(refined.results, "/", simplify = TRUE))]
 file.names <- str_remove_all(file.names, ".rds")

--- a/Figure2.qmd
+++ b/Figure2.qmd
@@ -25,7 +25,7 @@ library(scater)
 ## Figure 2A: Performance
 
 ```{r}
-data_dir <- "~/Documents/GitHub/Ibex.manuscript/data/trainingRuns/modelPerformance"
+data_dir <- "./data/trainingRuns/modelPerformance"
 
 # List all files in the director
 performance.results <- list.files(data_dir, full.names = TRUE)
@@ -86,7 +86,7 @@ ggsave("./outputs/Figure2/Figure2A.pdf", height = 8.5, width = 5)
 ## Figure 2B: Encoding Time
 
 ```{r}
-data_dir <- "~/Documents/GitHub/Ibex.manuscript/data/trainingRuns/encodingTime"
+data_dir <- "./data/trainingRuns/encodingTime"
 
 # List all files in the director
 encode.results <- list.files(data_dir, full.names = TRUE)
@@ -165,7 +165,7 @@ ggsave("./outputs/Figure2/Figure2B.pdf", height = 5, width = 10.5)
 ## Figure 2C: Edit Distance Distributions
 
 ```{r}
-data_dir <- "~/Documents/GitHub/Ibex.manuscript/data/trainingRuns/editDistances"
+data_dir <- "./data/trainingRuns/editDistances"
 
 # List all files in the director
 edit.results <- list.files(data_dir, full.names = TRUE)

--- a/Figure4.qmd
+++ b/Figure4.qmd
@@ -376,6 +376,8 @@ The process is as follows:
 Here, we define the cross-validation strategy. We first identify all unique clonotypes, split them into 5 folds, and then create index lists for `caret` to use for training and testing, ensuring no clonotype overlap.
 
 ```{r}
+original_data <- SeuratMerge[[]]
+original_data$IGH.clonotypes <- str_split(original_data$CTaa, "_", simplify = TRUE)[,1]
 ## =================================================================
 ## Part 1: Stratified Group Train/Test Split & CV Fold Creation
 ## =================================================================
@@ -664,9 +666,6 @@ legend(
 
 
 ```{r}
-# Stop the parallel cluster
-stopCluster(cl)
-
 # Print session info for reproducibility
 sessionInfo()
 ```


### PR DESCRIPTION
This commit addresses several issues in the R Markdown files for generating figures:

- Replaced absolute file paths with relative paths in `Figure1.qmd` and `Figure2.qmd` to ensure reproducibility.
- Corrected typos and stray characters in `Figure1.qmd`.
- Fixed a bug in `Figure4.qmd` where the `original_data` variable was not defined before use in the machine learning evaluation.
- Removed a redundant `stopCluster(cl)` call in `Figure4.qmd`.